### PR TITLE
Detect YouTube URLs with feature=player_embedded

### DIFF
--- a/main.py
+++ b/main.py
@@ -494,7 +494,7 @@ def checkfiles():
                     r"{{\s*?[Ff]rom\s[Yy]ou[Tt]ube\s*(?:\||\|1\=|\s*?)(?:\s*)(?:1|=\||)(?:=|)([^\"&?\/ ]{11})", source_area).group(1)
             except AttributeError:
                 try:
-                    YouTubeVideoId = re.search(r"https?\:\/\/(?:www|m|)(?:|\.)youtube\.com/watch\Wv\=([^\"&?\/ ]{11})", source_area).group(1)
+                    YouTubeVideoId = re.search(r"https?\:\/\/(?:www|m|)(?:|\.)youtube\.com/watch\W(?:feature\\=player_embedded&)?v\=([^\"&?\/ ]{11})", source_area).group(1)
                 except AttributeError:
                     out(
                         "PARSING FAILED - Can't get YouTubeVideoId",


### PR DESCRIPTION
To detect YouTube video ids in URLS like below

https://commons.wikimedia.org/wiki/File:2012_February_16_Representatives_Cummings_and_Maloney_opening_statements_at_US_Congress_contraception_hearing.ogv
https://www.youtube.com/watch?feature=player_embedded&v=89g0_R_iZcE